### PR TITLE
(SIMP-604) Migrate to simplib and simpcat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,7 @@ fixtures:
     augeasproviders_sysctl: "git://github.com/simp/augeasproviders_sysctl"
     augeasproviders_core: "git://github.com/simp/augeasproviders_core"
     common: "git://github.com/simp/pupmod-simp-common"
+    simplib: 'git://github.com/simp/pupmod-simp-simplib'
     stdlib: "git://github.com/simp/puppetlabs-stdlib"
     sysctl: "git://github.com/simp/pupmod-simp-sysctl"
   symlinks:

--- a/build/pupmod-libvirt.spec
+++ b/build/pupmod-libvirt.spec
@@ -1,13 +1,14 @@
 Summary: Libvirt Puppet Module
 Name: pupmod-libvirt
 Version: 4.1.0
-Release: 15
+Release: 16
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: pupmod-iptables >= 4.1.0-3
 Requires: pupmod-common >= 4.1.0-4
+Requires: pupmod-simplib >= 1.0.0-0
 Requires: pupmod-functions >= 2.1.0
 Requires: pupmod-sysctl >= 4.1.0-2
 Requires: puppet >= 3.3.0
@@ -60,6 +61,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-16
+- migration to simplib and simpcat (lib/ only)
+
 * Fri Jan 16 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-15
 - Changed puppet-server requirement to puppet
 


### PR DESCRIPTION
Before this commit, common SIMP-related custom functions were been kept
in either `simp-common` or `simp-functions`, and the `concat` function
was provided by the `simp-concat` module.  These functions are now
provides by the `simp-simplib` and `simp-simpcat` modules, respectively.

This update replaces all requirements in the RPM spec file,
metadata.json, or .fixtures.yml to reflect the migration to the new
modules.

SIMP-601 #comment Migrated `pupmod-simp-libvirt`.
SIMP-604 #comment Updated `pupmod-simp-libvirt`.