### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,3 +1,5 @@
-Requires: pupmod-simp-iptables >= 4.1.0-3
-Requires: pupmod-simp-sysctl >= 4.1.0-2
 Obsoletes: pupmod-libvirt-test >= 0.0.1
+Requires: pupmod-simp-simplib < 2.0.0-0
+Requires: pupmod-simp-simplib >= 1.3.1-0
+Requires: pupmod-simp-sysctl < 5.0.0-0
+Requires: pupmod-simp-sysctl >= 4.2.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-libvirt",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "author": "simp",
   "summary": "manages Kibana 3 in a SIMP-compatible environment",
   "license": "Apache-2.0",
@@ -15,20 +15,12 @@
   ],
   "dependencies": [
     {
-      "name": "simp-apache",
-      "version_requirement": ">= 4.0.0"
-    },
-    {
       "name": "simp-simplib",
-      "version_requirement": ">= 1.0.0"
-    },
-    {
-      "name": "simp-iptables",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     },
     {
       "name": "simp-sysctl",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.2.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-libvirt`
SIMP-1621 #close