### PR TITLE
(SIMP-1692) Point fixtures to `5.X` branches

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,15 +2,19 @@
 fixtures:
   repositories:
     augeasproviders_core:
-      repo: 'https://github.com/simp/augeasproviders_core'
-      branch: 'simp-master'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_core
     augeasproviders_sysctl:
-      repo: 'https://github.com/simp/augeasproviders_sysctl'
-      branch: 'simp-master'
-    simplib: 'https://github.com/simp/pupmod-simp-simplib'
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_sysctl
+    simplib:
+      repo: https://github.com/simp/pupmod-simp-simplib
+      branch: 5.X
     stdlib:
-      repo: 'https://github.com/simp/puppetlabs-stdlib'
-      branch: 'simp-master'
-    sysctl: 'https://github.com/simp/pupmod-simp-sysctl'
+      branch: 5.X
+      repo: https://github.com/simp/puppetlabs-stdlib
+    sysctl:
+      repo: https://github.com/simp/pupmod-simp-sysctl
+      branch: 5.X
   symlinks:
     libvirt: "#{source_dir}"


### PR DESCRIPTION
This commit marks the transition of mainline SIMP development away from
4.x/5.x.  From this point on, the `master` branch will be used to target SIMP
6.x.

This commit updates `fixtures.yml` to reference the newly-created `5.X` branch
in each `simp/` repository.

SIMP-1692 #comment updated `.fixtures.yml` in libvirt