### PR TITLE
(SIMP-2465) Fix a bug in the newvm.erb template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,58 @@
+---
+puppet-syntax:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.1
+  script:
+    - bundle install
+    - bundle exec rake syntax
+puppet-lint:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.1
+  script:
+    - bundle install
+    - bundle exec rake lint
+puppet-metadata:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.1
+  script:
+    - bundle install
+    - bundle exec rake metadata
+unit-test-ruby-2.1:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.1
+  script:
+    - bundle install
+    - bundle exec rake spec
+unit-test-ruby-2.2:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.2
+  allow_failure: true
+  script:
+    - bundle install
+    - bundle exec rake spec
+unit-test-ruby-2.3:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.3
+  allow_failure: true
+  script:
+    - bundle install
+    - bundle exec rake spec
+acceptance-test:
+  stage: test
+  tags:
+    - beaker
+  script:
+    - bundle install --no-binstubs --path=vendor
+    - bundle exec rake acceptance

--- a/spec/defines/data/default.txt
+++ b/spec/defines/data/default.txt
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+
+still_running () { ps -f -C qemu-kvm | grep 'foo_vm' | grep 'no-reboot' >& /dev/null; return $?; }
+
+ignore='false'
+if [ "$1" == '-i' ]; then
+  ignore='true'
+fi
+
+if [ "$ignore" == 'true' ] || [ `ls "/tmp/test_libvirt/foo_vm" 2>/dev/null | wc -l` -eq 0 ]; then
+  mkdir -p -m 750 "/tmp/test_libvirt/foo_vm";
+else
+  echo "VM foo_vm already exists, not creating";
+  exit 0;
+fi
+
+/usr/bin/virt-install -n "foo_vm" -r 512 --noautoconsole --os-variant=rhel6 --os-type=linux -w bridge:virbr0 --vcpus=1 --graphics vnc,keymap=en_us --disk=path='/tmp/test_libvirt/foo_vm/Disk1',size=50,sparse='false' -v --accelerate --sound --watchdog default --pxe
+
+/usr/bin/virsh autostart foo_vm;
+
+echo -n "Installing foo_vm: "
+
+while still_running; do
+  echo -n '>';
+  sleep 5;
+done
+
+echo
+
+sleep 5;
+
+echo "Starting foo_vm";
+
+/usr/bin/virsh start foo_vm;
+
+# Fire off a KSM run if it exists.
+if [ -d /sys/kernel/mm/ksm ]; then
+  echo '1' > /sys/kernel/mm/ksm/run
+fi

--- a/spec/defines/data/increased_vcpus.txt
+++ b/spec/defines/data/increased_vcpus.txt
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+
+still_running () { ps -f -C qemu-kvm | grep 'foo_vm' | grep 'no-reboot' >& /dev/null; return $?; }
+
+ignore='false'
+if [ "$1" == '-i' ]; then
+  ignore='true'
+fi
+
+if [ "$ignore" == 'true' ] || [ `ls "/tmp/test_libvirt/foo_vm" 2>/dev/null | wc -l` -eq 0 ]; then
+  mkdir -p -m 750 "/tmp/test_libvirt/foo_vm";
+else
+  echo "VM foo_vm already exists, not creating";
+  exit 0;
+fi
+
+/usr/bin/virt-install -n "foo_vm" -r 512 --noautoconsole --os-variant=rhel6 --os-type=linux -w bridge:virbr0 --vcpus=4 --graphics vnc,keymap=en_us --disk=path='/tmp/test_libvirt/foo_vm/Disk1',size=50,sparse='false' -v --accelerate --sound --watchdog default --pxe
+
+/usr/bin/virsh autostart foo_vm;
+
+echo -n "Installing foo_vm: "
+
+while still_running; do
+  echo -n '>';
+  sleep 5;
+done
+
+echo
+
+sleep 5;
+
+echo "Starting foo_vm";
+
+/usr/bin/virsh start foo_vm;
+
+# Fire off a KSM run if it exists.
+if [ -d /sys/kernel/mm/ksm ]; then
+  echo '1' > /sys/kernel/mm/ksm/run
+fi

--- a/spec/defines/data/larger_disk_size.txt
+++ b/spec/defines/data/larger_disk_size.txt
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+
+still_running () { ps -f -C qemu-kvm | grep 'foo_vm' | grep 'no-reboot' >& /dev/null; return $?; }
+
+ignore='false'
+if [ "$1" == '-i' ]; then
+  ignore='true'
+fi
+
+if [ "$ignore" == 'true' ] || [ `ls "/tmp/test_libvirt/foo_vm" 2>/dev/null | wc -l` -eq 0 ]; then
+  mkdir -p -m 750 "/tmp/test_libvirt/foo_vm";
+else
+  echo "VM foo_vm already exists, not creating";
+  exit 0;
+fi
+
+/usr/bin/virt-install -n "foo_vm" -r 512 --noautoconsole --os-variant=rhel6 --os-type=linux -w bridge:virbr0 --vcpus=1 --graphics vnc,keymap=en_us --disk=path='/tmp/test_libvirt/foo_vm/Disk1',size=100,sparse='false' -v --accelerate --sound --watchdog default --pxe
+
+/usr/bin/virsh autostart foo_vm;
+
+echo -n "Installing foo_vm: "
+
+while still_running; do
+  echo -n '>';
+  sleep 5;
+done
+
+echo
+
+sleep 5;
+
+echo "Starting foo_vm";
+
+/usr/bin/virsh start foo_vm;
+
+# Fire off a KSM run if it exists.
+if [ -d /sys/kernel/mm/ksm ]; then
+  echo '1' > /sys/kernel/mm/ksm/run
+fi

--- a/spec/defines/data/larger_memory_size.txt
+++ b/spec/defines/data/larger_memory_size.txt
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+
+still_running () { ps -f -C qemu-kvm | grep 'foo_vm' | grep 'no-reboot' >& /dev/null; return $?; }
+
+ignore='false'
+if [ "$1" == '-i' ]; then
+  ignore='true'
+fi
+
+if [ "$ignore" == 'true' ] || [ `ls "/tmp/test_libvirt/foo_vm" 2>/dev/null | wc -l` -eq 0 ]; then
+  mkdir -p -m 750 "/tmp/test_libvirt/foo_vm";
+else
+  echo "VM foo_vm already exists, not creating";
+  exit 0;
+fi
+
+/usr/bin/virt-install -n "foo_vm" -r 1024 --noautoconsole --os-variant=rhel6 --os-type=linux -w bridge:virbr0 --vcpus=1 --graphics vnc,keymap=en_us --disk=path='/tmp/test_libvirt/foo_vm/Disk1',size=50,sparse='false' -v --accelerate --sound --watchdog default --pxe
+
+/usr/bin/virsh autostart foo_vm;
+
+echo -n "Installing foo_vm: "
+
+while still_running; do
+  echo -n '>';
+  sleep 5;
+done
+
+echo
+
+sleep 5;
+
+echo "Starting foo_vm";
+
+/usr/bin/virsh start foo_vm;
+
+# Fire off a KSM run if it exists.
+if [ -d /sys/kernel/mm/ksm ]; then
+  echo '1' > /sys/kernel/mm/ksm/run
+fi

--- a/spec/defines/data/specify_disk_opts.txt
+++ b/spec/defines/data/specify_disk_opts.txt
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+
+still_running () { ps -f -C qemu-kvm | grep 'foo_vm' | grep 'no-reboot' >& /dev/null; return $?; }
+
+ignore='false'
+if [ "$1" == '-i' ]; then
+  ignore='true'
+fi
+
+if [ "$ignore" == 'true' ] || [ `ls "/tmp/test_libvirt/foo_vm" 2>/dev/null | wc -l` -eq 0 ]; then
+  mkdir -p -m 750 "/tmp/test_libvirt/foo_vm";
+else
+  echo "VM foo_vm already exists, not creating";
+  exit 0;
+fi
+
+/usr/bin/virt-install -n "foo_vm" -r 512 --noautoconsole --os-variant=rhel6 --os-type=linux -w bridge:virbr0 --vcpus=1 --graphics vnc,keymap=en_us --disk=path='/tmp/test_libvirt/foo_vm/Disk1',size=100,sparse='false',bus=1,format=qcow,io=test -v --accelerate --sound --watchdog default --pxe
+
+/usr/bin/virsh autostart foo_vm;
+
+echo -n "Installing foo_vm: "
+
+while still_running; do
+  echo -n '>';
+  sleep 5;
+done
+
+echo
+
+sleep 5;
+
+echo "Starting foo_vm";
+
+/usr/bin/virsh start foo_vm;
+
+# Fire off a KSM run if it exists.
+if [ -d /sys/kernel/mm/ksm ]; then
+  echo '1' > /sys/kernel/mm/ksm/run
+fi

--- a/spec/defines/vm_spec.rb
+++ b/spec/defines/vm_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-
 describe 'libvirt::vm' do
 
   let(:title) {'foo_vm'}
@@ -7,12 +6,44 @@ describe 'libvirt::vm' do
     :operatingsystemmajrelease => '6',
     :operatingsystem   => 'CentOS'
   }}
-  let(:params) {{
-    :size       => 50,
-    :pxe        => true,
-    :target_dir => '/tmp/test_libvirt'
-  }}
+  {
+    "default" => {
+      :size       => 50,
+      :pxe        => true,
+      :target_dir => '/tmp/test_libvirt'
+    },
+    "larger_disk_size" => {
+      :size       => 100,
+      :pxe        => true,
+      :target_dir => '/tmp/test_libvirt'
+    },
+    "specify_disk_opts" => {
+      :size => 100,
+      :disk_opts       => { 'bus' => '1', 'format' => 'qcow', 'io' => 'test'},
+        :pxe        => true,
+        :target_dir => '/tmp/test_libvirt'
+    },
+    "increased_vcpus" => {
+      :vcpus       => 4,
+      :size => 50,
+      :pxe        => true,
+      :target_dir => '/tmp/test_libvirt'
+    },
+    "larger_memory_size" => {
+      :mem       => 1024,
+      :size     => 50,
+      :pxe        => true,
+      :target_dir => '/tmp/test_libvirt'
+    }
 
-  it { is_expected.to create_file('/tmp/test_libvirt').with_ensure('directory') }
-  it { is_expected.to create_file('/usr/local/sbin/vm-create-foo_vm.sh').with_content(/size=50/) }
+  }.each do |name, hash|
+    context "when test case = #{name}" do
+      let(:params) {
+        hash
+      }
+      it { is_expected.to create_file('/tmp/test_libvirt').with_ensure('directory') }
+      create_vm = File.open("#{File.dirname(__FILE__)}/data/#{name}.txt", "rb").read;
+      it { is_expected.to create_file('/usr/local/sbin/vm-create-foo_vm.sh').with_content(create_vm) }
+    end
+  end
 end

--- a/templates/newvm.erb
+++ b/templates/newvm.erb
@@ -22,11 +22,11 @@ if not @networks.nil? then
       )
     end
 
-    t_vinst_command += " -w #{@t_network['type']}:#{@t_network['target']}"
-    t_network['model'] and t_vinst_command += ",model=#{@t_network['model']}"
+    t_vinst_command += " -w #{t_network['type']}:#{t_network['target']}"
+    t_network['model'] and t_vinst_command += ",model=#{t_network['model']}"
 
     if t_network['mac'] then
-      t_vinst_command += ",mac=#{@t_network['mac']}"
+      t_vinst_command += ",mac=#{t_network['mac']}"
     elsif !@mac_addr.nil? and !used_mac_addr then
       t_vinst_command += ",mac=#{@mac_addr}"
       used_mac_addr = true
@@ -51,13 +51,13 @@ t_valid_vcpu_options = ['maxvcpus','sockets','cores','threads']
 # Validate that all of the vcpu options passed are valid.
 if !@vcpu_options.nil? and !(@vcpu_options.keys - t_valid_vcpu_options).nil? then
   raise Puppet::ParseError.new(
-    "Error: vcpu_options was passed an invalid option. Valid options include '#{@t_valid_vcpu_options.join(', ')}'"
+    "Error: vcpu_options was passed an invalid option. Valid options include '#{t_valid_vcpu_options.join(', ')}'"
   )
 end
 
 if not @vcpu_options.nil? then
   t_valid_vcpu_options.each do |t_valid_vcpu_option|
-  @vcpu_options[t_valid_vcpu_option] and t_vinst_command += ",#{@t_valid_vcpu_option}=#{@vcpu_options[t_valid_vcpu_option]}"
+  @vcpu_options[t_valid_vcpu_option] and t_vinst_command += ",#{t_valid_vcpu_option}=#{@vcpu_options[t_valid_vcpu_option]}"
   end
 end
 
@@ -119,7 +119,7 @@ t_sec_type = ['static','dynamic']
 if not @security.nil? then
   if not t_sec_type.include?(@security['type']) then
     raise Puppet::ParseError.new(
-      "Error: 'security' => 'type' must be one of '#{@t_sec_type.join(", ")}'"
+      "Error: 'security' => 'type' must be one of '#{t_sec_type.join(", ")}'"
     )
   end
 
@@ -147,7 +147,7 @@ end
 if not @disk_opts.nil? then
   t_disk_opts.each do |t_disk_opt|
     if @disk_opts[t_disk_opt] then
-      t_vinst_command += ",#{@t_disk_opt}=#{@disk_opts[t_disk_opt]}"
+      t_vinst_command += ",#{t_disk_opt}=#{@disk_opts[t_disk_opt]}"
     end
   end
 end


### PR DESCRIPTION
The newvm.erb template in pupmod-simp-libvirt has some variable scoping
issues in both 5.X and 6.X. Per our older naming scheme, any variable
that starts with t_ is a local variable and should not be scoped
globally with @.

Add more comprehensive tests to check for regressions.

Add the gitlabci.yml while I'm here

SIMP-2465 #close