### PR TITLE
(SIMP-3056) Add optional polkit rules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,7 @@ fixtures:
   repositories:
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_sysctl: https://github.com/simp/augeasproviders_sysctl
-    polkit: https://github.com/jeefberkey/pupmod-simp-polkit
+    polkit: https://github.com/simp/pupmod-simp-polkit
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
   symlinks:

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,10 @@
 ---
 fixtures:
   repositories:
-    augeasproviders_core: 'https://github.com/simp/augeasproviders_core'
-    augeasproviders_sysctl: 'https://github.com/simp/augeasproviders_sysctl'
-    simplib: 'https://github.com/simp/pupmod-simp-simplib'
-    stdlib: 'https://github.com/simp/puppetlabs-stdlib'
+    augeasproviders_core: https://github.com/simp/augeasproviders_core
+    augeasproviders_sysctl: https://github.com/simp/augeasproviders_sysctl
+    polkit: https://github.com/jeefberkey/pupmod-simp-polkit
+    simplib: https://github.com/simp/pupmod-simp-simplib
+    stdlib: https://github.com/simp/puppetlabs-stdlib
   symlinks:
     libvirt: "#{source_dir}"

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,5 +2,8 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-140chars-check
+--no-empty_string-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+# This is here because the code can't handle lookups in parameters and we have
+# a LOT of those
+--no-parameter_order-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
-#  PE/SIMP versions
-#  app    pup  ruby
-# 2015.2  4.3  2.1.7
-# 2015.3  4.3  2.1.8
-# 2016.1  4.4  2.1.9
-# 2016.2  4.5  2.1.9
-# S6.0.0  4.7  2.1.9
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2015.2   4.2   2.1.7  2017-03-17
+# PE 2015.3   4.3   2.1.8  2017-03-17
+# PE 2016.1   4.4   2.1.9  2017-03-17 (yes: all three EOL on the same day!)
+# PE 2016.2   4.5   2.1.9  2017-04-30
+# PE 2016.4   4.7   2.1.9  TBD (LTS)
+# PE 2016.5   4.8   2.1.9  TBD
+# SIMP6.0.0   4.8   2.1.9  TBD
 ---
 language: ruby
 sudo: false
@@ -30,13 +33,13 @@ env:
     - PUPPET_VERSION="~> 4.5.0"
     - PUPPET_VERSION="~> 4.4.0"
     - PUPPET_VERSION="~> 4.3.0"
-    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
   fast_finish: true
   allow_failures:
     - env: PUPPET_VERSION="~> 4.9.4"
+    - env: PUPPET_VERSION="~> 4.7.0"
     - env: PUPPET_VERSION="~> 4.5.0"
-    - env: PUPPET_VERSION="~> 3.8.0"
     - env: PUPPET_VERSION="~> 4.4.0"
     - env: PUPPET_VERSION="~> 4.3.0"
-    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.2.0"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Apr 17 2017 Nick Miller <nick.miller@onyxpoint.com> - 5.0.3-0
+- Add class to manage polkit rules for libvirt
+
 * Wed Apr 12 2017 Nick Markowski <nmarkowski@keywcorp.com> - 5.0.3-0
 - Added some in-code docs to help users track down libvirt dependencies.
 

--- a/Gemfile
+++ b/Gemfile
@@ -35,11 +35,7 @@ group :development do
 end
 
 group :system_tests do
-  # This patch is required to fix Beaker's broken `aio` handling and provide support for SuSE
-  # If you want to use 'bundle update --local', comment out this line and uncomment the next line
-  # If you do this, please remember not to check in that change.
-  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-978-2.51.0'
-  # gem 'beaker'
+  gem 'beaker'
   gem 'beaker-rspec'
   gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
 end

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :test do
   gem 'hiera-puppet-helper'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
+  gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
@@ -24,7 +25,6 @@ group :development do
   gem 'travis-lint'
   gem 'travish'
   gem 'puppet-blacksmith'
-  gem 'puppet-strings'
   gem 'guard-rake'
   gem 'pry'
   gem 'pry-doc'
@@ -35,8 +35,11 @@ group :development do
 end
 
 group :system_tests do
-  # This patch is required to fix Beaker's broken `aio` handling
-  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-931-2.51.0'
+  # This patch is required to fix Beaker's broken `aio` handling and provide support for SuSE
+  # If you want to use 'bundle update --local', comment out this line and uncomment the next line
+  # If you do this, please remember not to check in that change.
+  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-978-2.51.0'
+  # gem 'beaker'
   gem 'beaker-rspec'
   gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
 require 'simp/rake/pupmod/helpers'
+require 'puppet-strings/tasks'
 
 Simp::Rake::Pupmod::Helpers.new(File.dirname(__FILE__))
-

--- a/manifests/polkit.pp
+++ b/manifests/polkit.pp
@@ -9,12 +9,12 @@
 # @param rulesd Location of the poklit rules directory
 #
 class libvirt::polkit (
-  Enum['present','absent'] $ensure   = 'present',
-  String                   $group    = 'virtusers',
-  Integer[0,99]            $priority = 10,
-  Polkit::Result           $result   = 'yes',
-  Boolean                  $local    = true,
-  Boolean                  $active   = true,
+  Enum['present','absent']      $ensure   = 'present',
+  Variant[String,Array[String]] $group    = 'virtusers',
+  Integer[0,99]                 $priority = 10,
+  Polkit::Result                $result   = 'yes',
+  Boolean                       $local    = true,
+  Boolean                       $active   = true,
 ) {
 
   polkit::authorization::basic_policy { "Allow users in ${group} to use libvirt":

--- a/manifests/polkit.pp
+++ b/manifests/polkit.pp
@@ -1,0 +1,30 @@
+# Add a rule file allowing members of a group to use libvirt
+#
+# @param ensure Create or destroy the rules file
+#
+# @param content An arbitrary string of javascript polkit configuration
+#
+# @param priority Priority of the file to be created
+#
+# @param rulesd Location of the poklit rules directory
+#
+class libvirt::polkit (
+  Enum['present','absent'] $ensure   = 'present',
+  String                   $group    = 'virtusers',
+  Integer[0,99]            $priority = 10,
+  Polkit::Result           $result   = 'yes',
+  Boolean                  $local    = true,
+  Boolean                  $active   = true,
+) {
+
+  polkit::authorization::basic_policy { "Allow users in ${group} to use libvirt":
+    ensure    => $ensure,
+    group     => $group,
+    priority  => $priority,
+    result    => $result,
+    local     => $local,
+    active    => $active,
+    action_id => 'org.libvirt.unix.manage',
+  }
+
+}

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": [
     {
-      "name": "simp-simplib",
+      "name": "simp/simplib",
       "version_requirement": ">= 3.1.0 < 4.0.0"
     },
     {
@@ -23,7 +23,11 @@
       "version_requirement": ">= 4.13.1 < 5.0.0"
     },
     {
-      "name": "herculesteam-augeasproviders_sysctl",
+      "name": "simp/polkit",
+      "version_requirement": ">= 6.1.0 < 7.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_sysctl",
       "version_requirement": ">= 2.1.0 < 3.0.0"
     }
   ],
@@ -46,8 +50,7 @@
     "requirements": [
     {
       "name": "puppet",
-      "version_requirement": "4.x"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     }
-  ],
-  "data_provider": "hiera"
+  ]
 }

--- a/spec/classes/polkit_spec.rb
+++ b/spec/classes/polkit_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'libvirt::polkit' do
+  supported_os = on_supported_os.delete_if { |e| e =~ /-6-/ } #TODO do this right
+  supported_os.each do |os, facts|
+  # on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'with default parameters' do
+        it { is_expected.to create_class('libvirt::polkit') }
+        it { is_expected.to create_polkit__authorization__basic_policy('Allow users in virtusers to use libvirt').with({
+          :ensure    => 'present',
+          :priority  => 10,
+          :action_id => 'org.libvirt.unix.manage'
+        }) }
+      end
+
+
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,7 +84,7 @@ RSpec.configure do |c|
     :production => {
       #:fqdn           => 'production.rspec.test.localdomain',
       :path           => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
-      :concat_basedir => '/tmp'
+      :concat_basedir => '/tmp',
     }
   }
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -28,11 +28,7 @@ RSpec.configure do |c|
     begin
       # Install modules and dependencies from spec/fixtures/modules
       copy_fixture_modules_to( hosts )
-      begin
-        server = only_host_with_role(hosts, 'server')
-      rescue ArgumentError =>e
-        server = only_host_with_role(hosts, 'default')
-      end
+      server = only_host_with_role(hosts, 'server')
 
       # Generate and install PKI certificates on each SUT
       Dir.mktmpdir do |cert_dir|


### PR DESCRIPTION
USe the new polkit defines to create polkit rules allowing users from
the `virtusers` (or configured) group to manage libvirt

SIMP-3056 #close