### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 5.2.1-0
+- Update the upper bound of stdlib to < 6.0.0
+- Workaround a change in behavior of ensure_packages with stdlib 5.x.
+  This change caused resource conflicts.
+- Update a URL in the README.md
+
 * Fri Sep 07 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 5.2.0-0
 - Update Hiera 4 to Hiera 5
 - Update badges and contribution guide URL in README.md

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ a compliance-management framework built on Puppet.
 
 If you find any issues, they can be submitted to our [JIRA](https://simp-project.atlassian.net/).
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 ## Work in Progress
 

--- a/manifests/ksm.pp
+++ b/manifests/ksm.pp
@@ -79,12 +79,9 @@ class libvirt::ksm (
   Optional[Integer]               $ksm_thres_const      = undef
 ) {
 
-  ensure_packages( $package_list,
-    {
-      'ensure' => $package_ensure,
-      'notify' => [ Service['ksmtuned'], Service['ksm'] ]
-    }
-  )
+  ensure_packages( $package_list, { 'ensure' => $package_ensure, } )
+
+  $package_list.each |String $pkg|  { Package[$pkg] ~> [ Service['ksmtuned'], Service['ksm'] ] }
 
   file { '/etc/ksmtuned.conf':
     owner   => 'root',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-libvirt",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "author": "SIMP Team",
   "summary": "manages libvirtd in a SIMP-compatible environment",
   "license": "Apache-2.0",
@@ -20,7 +20,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "simp/polkit",


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Workaround a change in behavior of ensure_packages with stdlib
  5.x that caused resource conflicts. This was the source of in
  the acceptance test failures.
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-libvit
SIMP-6169 #close